### PR TITLE
Add waxed items

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'net.minecraftforge.gradle'
 
 
-version = '1.18.2-0.0.0.1'
+version = '1.18.2-0.0.0.2'
 group = 'io.github.shadowgry.coppertools' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'coppertools'
 

--- a/src/main/java/com/github/shadowgry/coppertools/common/items/ModItems.java
+++ b/src/main/java/com/github/shadowgry/coppertools/common/items/ModItems.java
@@ -88,6 +88,58 @@ public class ModItems {
     public static final RegistryObject<ArmorItem> OXIDIZED_COPPER_LEGGINGS   = ITEMS.register("oxidized_copper_leggings",   () -> new ArmorItem(ModArmorMaterials.OXIDIZED_COPPER, EquipmentSlot.LEGS,  new Item.Properties().tab(CopperTools.TAB_COPPER_TOOLS)));
     public static final RegistryObject<ArmorItem> OXIDIZED_COPPER_BOOTS      = ITEMS.register("oxidized_copper_boots",      () -> new ArmorItem(ModArmorMaterials.OXIDIZED_COPPER, EquipmentSlot.FEET,  new Item.Properties().tab(CopperTools.TAB_COPPER_TOOLS)));
     
+    // Waxed Copper Items
+    public static final RegistryObject<ShovelItem>  WAXED_COPPER_SHOVEL  = ITEMS.register("waxed_copper_shovel",  () -> new ShovelItem( ModTiers.COPPER,  1.5F, -3.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<PickaxeItem> WAXED_COPPER_PICKAXE = ITEMS.register("waxed_copper_pickaxe", () -> new PickaxeItem(ModTiers.COPPER,  1,    -2.8F, new Item.Properties().tab(null)));
+    public static final RegistryObject<AxeItem>     WAXED_COPPER_AXE     = ITEMS.register("waxed_copper_axe",     () -> new AxeItem(    ModTiers.COPPER,  6.0F, -3.1F, new Item.Properties().tab(null)));
+    public static final RegistryObject<HoeItem>     WAXED_COPPER_HOE     = ITEMS.register("waxed_copper_hoe",     () -> new HoeItem(    ModTiers.COPPER, -2,    -1.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<SwordItem>   WAXED_COPPER_SWORD   = ITEMS.register("waxed_copper_sword",   () -> new SwordItem(  ModTiers.COPPER,  3,    -2.4F, new Item.Properties().tab(null)));
+
+    // Waxed Copper Armor
+    public static final RegistryObject<ArmorItem> WAXED_COPPER_CHESTPLATE = ITEMS.register("waxed_copper_chestplate", () -> new ArmorItem(ModArmorMaterials.COPPER, EquipmentSlot.CHEST, new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_COPPER_LEGGINGS   = ITEMS.register("waxed_copper_leggings",   () -> new ArmorItem(ModArmorMaterials.COPPER, EquipmentSlot.LEGS,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_COPPER_HELMET     = ITEMS.register("waxed_copper_helmet",     () -> new ArmorItem(ModArmorMaterials.COPPER, EquipmentSlot.HEAD,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_COPPER_BOOTS      = ITEMS.register("waxed_copper_boots",      () -> new ArmorItem(ModArmorMaterials.COPPER, EquipmentSlot.FEET,  new Item.Properties().tab(null)));
+    
+    // Waxed Exposed Copper Items
+    public static final RegistryObject<ShovelItem>  WAXED_EXPOSED_COPPER_SHOVEL  = ITEMS.register("waxed_exposed_copper_shovel",  () -> new ShovelItem( ModTiers.EXPOSED_COPPER,  1.5F, -3.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<PickaxeItem> WAXED_EXPOSED_COPPER_PICKAXE = ITEMS.register("waxed_exposed_copper_pickaxe", () -> new PickaxeItem(ModTiers.EXPOSED_COPPER,  1,    -2.8F, new Item.Properties().tab(null)));
+    public static final RegistryObject<AxeItem>     WAXED_EXPOSED_COPPER_AXE     = ITEMS.register("waxed_exposed_copper_axe",     () -> new AxeItem(    ModTiers.EXPOSED_COPPER,  6.0F, -3.1F, new Item.Properties().tab(null)));
+    public static final RegistryObject<HoeItem>     WAXED_EXPOSED_COPPER_HOE     = ITEMS.register("waxed_exposed_copper_hoe",     () -> new HoeItem(    ModTiers.EXPOSED_COPPER, -2,    -1.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<SwordItem>   WAXED_EXPOSED_COPPER_SWORD   = ITEMS.register("waxed_exposed_copper_sword",   () -> new SwordItem(  ModTiers.EXPOSED_COPPER,  3,    -2.4F, new Item.Properties().tab(null)));
+    
+    // Waxed Exposed Copper Armor
+    public static final RegistryObject<ArmorItem> WAXED_EXPOSED_COPPER_HELMET     = ITEMS.register("waxed_exposed_copper_helmet",     () -> new ArmorItem(ModArmorMaterials.EXPOSED_COPPER, EquipmentSlot.HEAD,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_EXPOSED_COPPER_CHESTPLATE = ITEMS.register("waxed_exposed_copper_chestplate", () -> new ArmorItem(ModArmorMaterials.EXPOSED_COPPER, EquipmentSlot.CHEST, new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_EXPOSED_COPPER_LEGGINGS   = ITEMS.register("waxed_exposed_copper_leggings",   () -> new ArmorItem(ModArmorMaterials.EXPOSED_COPPER, EquipmentSlot.LEGS,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_EXPOSED_COPPER_BOOTS      = ITEMS.register("waxed_exposed_copper_boots",      () -> new ArmorItem(ModArmorMaterials.EXPOSED_COPPER, EquipmentSlot.FEET,  new Item.Properties().tab(null)));
+    
+    // Waxed Weathered Copper Items
+    public static final RegistryObject<ShovelItem>  WAXED_WEATHERED_COPPER_SHOVEL  = ITEMS.register("waxed_weathered_copper_shovel",  () -> new ShovelItem( ModTiers.WEATHERED_COPPER,  1.5F, -3.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<PickaxeItem> WAXED_WEATHERED_COPPER_PICKAXE = ITEMS.register("waxed_weathered_copper_pickaxe", () -> new PickaxeItem(ModTiers.WEATHERED_COPPER,  1,    -2.8F, new Item.Properties().tab(null)));
+    public static final RegistryObject<AxeItem>     WAXED_WEATHERED_COPPER_AXE     = ITEMS.register("waxed_weathered_copper_axe",     () -> new AxeItem(    ModTiers.WEATHERED_COPPER,  6.0F, -3.1F, new Item.Properties().tab(null)));
+    public static final RegistryObject<HoeItem>     WAXED_WEATHERED_COPPER_HOE     = ITEMS.register("waxed_weathered_copper_hoe",     () -> new HoeItem(    ModTiers.WEATHERED_COPPER, -2,    -1.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<SwordItem>   WAXED_WEATHERED_COPPER_SWORD   = ITEMS.register("waxed_weathered_copper_sword",   () -> new SwordItem(  ModTiers.WEATHERED_COPPER,  3,    -2.4F, new Item.Properties().tab(null)));
+    
+    // Waxed Weathered Copper Armor
+    public static final RegistryObject<ArmorItem> WAXED_WEATHERED_COPPER_HELMET     = ITEMS.register("waxed_weathered_copper_helmet",     () -> new ArmorItem(ModArmorMaterials.WEATHERED_COPPER, EquipmentSlot.HEAD,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_WEATHERED_COPPER_CHESTPLATE = ITEMS.register("waxed_weathered_copper_chestplate", () -> new ArmorItem(ModArmorMaterials.WEATHERED_COPPER, EquipmentSlot.CHEST, new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_WEATHERED_COPPER_LEGGINGS   = ITEMS.register("waxed_weathered_copper_leggings",   () -> new ArmorItem(ModArmorMaterials.WEATHERED_COPPER, EquipmentSlot.LEGS,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_WEATHERED_COPPER_BOOTS      = ITEMS.register("waxed_weathered_copper_boots",      () -> new ArmorItem(ModArmorMaterials.WEATHERED_COPPER, EquipmentSlot.FEET,  new Item.Properties().tab(null)));
+    
+    // Waxed Oxidized Copper Items
+    public static final RegistryObject<ShovelItem>  WAXED_OXIDIZED_COPPER_SHOVEL  = ITEMS.register("waxed_oxidized_copper_shovel",  () -> new ShovelItem( ModTiers.OXIDIZED_COPPER,  1.5F, -3.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<PickaxeItem> WAXED_OXIDIZED_COPPER_PICKAXE = ITEMS.register("waxed_oxidized_copper_pickaxe", () -> new PickaxeItem(ModTiers.OXIDIZED_COPPER,  1,    -2.8F, new Item.Properties().tab(null)));
+    public static final RegistryObject<AxeItem>     WAXED_OXIDIZED_COPPER_AXE     = ITEMS.register("waxed_oxidized_copper_axe",     () -> new AxeItem(    ModTiers.OXIDIZED_COPPER,  6.0F, -3.1F, new Item.Properties().tab(null)));
+    public static final RegistryObject<HoeItem>     WAXED_OXIDIZED_COPPER_HOE     = ITEMS.register("waxed_oxidized_copper_hoe",     () -> new HoeItem(    ModTiers.OXIDIZED_COPPER, -2,    -1.0F, new Item.Properties().tab(null)));
+    public static final RegistryObject<SwordItem>   WAXED_OXIDIZED_COPPER_SWORD   = ITEMS.register("waxed_oxidized_copper_sword",   () -> new SwordItem(  ModTiers.OXIDIZED_COPPER,  3,    -2.4F, new Item.Properties().tab(null)));
+    
+    // Waxed Oxidized Copper Armor
+    public static final RegistryObject<ArmorItem> WAXED_OXIDIZED_COPPER_HELMET     = ITEMS.register("waxed_oxidized_copper_helmet",     () -> new ArmorItem(ModArmorMaterials.OXIDIZED_COPPER, EquipmentSlot.HEAD,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_OXIDIZED_COPPER_CHESTPLATE = ITEMS.register("waxed_oxidized_copper_chestplate", () -> new ArmorItem(ModArmorMaterials.OXIDIZED_COPPER, EquipmentSlot.CHEST, new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_OXIDIZED_COPPER_LEGGINGS   = ITEMS.register("waxed_oxidized_copper_leggings",   () -> new ArmorItem(ModArmorMaterials.OXIDIZED_COPPER, EquipmentSlot.LEGS,  new Item.Properties().tab(null)));
+    public static final RegistryObject<ArmorItem> WAXED_OXIDIZED_COPPER_BOOTS      = ITEMS.register("waxed_oxidized_copper_boots",      () -> new ArmorItem(ModArmorMaterials.OXIDIZED_COPPER, EquipmentSlot.FEET,  new Item.Properties().tab(null)));
+    
     public static void registerItems() {
         ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
     }

--- a/src/main/resources/assets/coppertools/lang/en_au.json
+++ b/src/main/resources/assets/coppertools/lang/en_au.json
@@ -43,5 +43,49 @@
   "item.coppertools.oxidized_copper_helmet":     "Oxidised Copper Helmet",
   "item.coppertools.oxidized_copper_chestplate": "Oxidised Copper Chestplate",
   "item.coppertools.oxidized_copper_leggings":   "Oxidised Copper Leggings",
-  "item.coppertools.oxidized_copper_boots":      "Oxidised Copper Boots"
+  "item.coppertools.oxidized_copper_boots":      "Oxidised Copper Boots",
+  
+  "item.coppertools.waxed_copper_shovel":  "Waxed Copper Shovel",
+  "item.coppertools.waxed_copper_pickaxe": "Waxed Copper Pickaxe",
+  "item.coppertools.waxed_copper_axe":     "Waxed Copper Axe",
+  "item.coppertools.waxed_copper_hoe":     "Waxed Copper Hoe",
+  "item.coppertools.waxed_copper_sword":   "Waxed Copper Sword",
+  
+  "item.coppertools.waxed_copper_helmet":     "Waxed Copper Helmet",
+  "item.coppertools.waxed_copper_chestplate": "Waxed Copper Chestplate",
+  "item.coppertools.waxed_copper_leggings":   "Waxed Copper Leggings",
+  "item.coppertools.waxed_copper_boots":      "Waxed Copper Boots",
+  
+  "item.coppertools.waxed_exposed_copper_shovel":  "Waxed Exposed Copper Shovel",
+  "item.coppertools.waxed_exposed_copper_pickaxe": "Waxed Exposed Copper Pickaxe",
+  "item.coppertools.waxed_exposed_copper_axe":     "Waxed Exposed Copper Axe",
+  "item.coppertools.waxed_exposed_copper_hoe":     "Waxed Exposed Copper Hoe",
+  "item.coppertools.waxed_exposed_copper_sword":   "Waxed Exposed Copper Sword",
+  
+  "item.coppertools.waxed_exposed_copper_helmet":     "Waxed Exposed Copper Helmet",
+  "item.coppertools.waxed_exposed_copper_chestplate": "Waxed Exposed Copper Chestplate",
+  "item.coppertools.waxed_exposed_copper_leggings":   "Waxed Exposed Copper Leggings",
+  "item.coppertools.waxed_exposed_copper_boots":      "Waxed Exposed Copper Boots",
+  
+  "item.coppertools.waxed_weathered_copper_shovel":  "Waxed Weathered Copper Shovel",
+  "item.coppertools.waxed_weathered_copper_pickaxe": "Waxed Weathered Copper Pickaxe",
+  "item.coppertools.waxed_weathered_copper_axe":     "Waxed Weathered Copper Axe",
+  "item.coppertools.waxed_weathered_copper_hoe":     "Waxed Weathered Copper Hoe",
+  "item.coppertools.waxed_weathered_copper_sword":   "Waxed Weathered Copper Sword",
+  
+  "item.coppertools.waxed_weathered_copper_helmet":     "Waxed Weathered Copper Helmet",
+  "item.coppertools.waxed_weathered_copper_chestplate": "Waxed Weathered Copper Chestplate",
+  "item.coppertools.waxed_weathered_copper_leggings":   "Waxed Weathered Copper Leggings",
+  "item.coppertools.waxed_weathered_copper_boots":      "Waxed Weathered Copper Boots",
+  
+  "item.coppertools.waxed_oxidized_copper_shovel":  "Waxed Oxidised Copper Shovel",
+  "item.coppertools.waxed_oxidized_copper_pickaxe": "Waxed Oxidised Copper Pickaxe",
+  "item.coppertools.waxed_oxidized_copper_axe":     "Waxed Oxidised Copper Axe",
+  "item.coppertools.waxed_oxidized_copper_hoe":     "Waxed Oxidised Copper Hoe",
+  "item.coppertools.waxed_oxidized_copper_sword":   "Waxed Oxidised Copper Sword",
+  
+  "item.coppertools.waxed_oxidized_copper_helmet":     "Waxed Oxidised Copper Helmet",
+  "item.coppertools.waxed_oxidized_copper_chestplate": "Waxed Oxidised Copper Chestplate",
+  "item.coppertools.waxed_oxidized_copper_leggings":   "Waxed Oxidised Copper Leggings",
+  "item.coppertools.waxed_oxidized_copper_boots":      "Waxed Oxidised Copper Boots"
 }

--- a/src/main/resources/assets/coppertools/lang/en_us.json
+++ b/src/main/resources/assets/coppertools/lang/en_us.json
@@ -43,5 +43,49 @@
   "item.coppertools.oxidized_copper_helmet":     "Oxidized Copper Helmet",
   "item.coppertools.oxidized_copper_chestplate": "Oxidized Copper Chestplate",
   "item.coppertools.oxidized_copper_leggings":   "Oxidized Copper Leggings",
-  "item.coppertools.oxidized_copper_boots":      "Oxidized Copper Boots"
+  "item.coppertools.oxidized_copper_boots":      "Oxidized Copper Boots",
+  
+  "item.coppertools.waxed_copper_shovel":  "Waxed Copper Shovel",
+  "item.coppertools.waxed_copper_pickaxe": "Waxed Copper Pickaxe",
+  "item.coppertools.waxed_copper_axe":     "Waxed Copper Axe",
+  "item.coppertools.waxed_copper_hoe":     "Waxed Copper Hoe",
+  "item.coppertools.waxed_copper_sword":   "Waxed Copper Sword",
+  
+  "item.coppertools.waxed_copper_helmet":     "Waxed Copper Helmet",
+  "item.coppertools.waxed_copper_chestplate": "Waxed Copper Chestplate",
+  "item.coppertools.waxed_copper_leggings":   "Waxed Copper Leggings",
+  "item.coppertools.waxed_copper_boots":      "Waxed Copper Boots",
+  
+  "item.coppertools.waxed_exposed_copper_shovel":  "Waxed Exposed Copper Shovel",
+  "item.coppertools.waxed_exposed_copper_pickaxe": "Waxed Exposed Copper Pickaxe",
+  "item.coppertools.waxed_exposed_copper_axe":     "Waxed Exposed Copper Axe",
+  "item.coppertools.waxed_exposed_copper_hoe":     "Waxed Exposed Copper Hoe",
+  "item.coppertools.waxed_exposed_copper_sword":   "Waxed Exposed Copper Sword",
+  
+  "item.coppertools.waxed_exposed_copper_helmet":     "Waxed Exposed Copper Helmet",
+  "item.coppertools.waxed_exposed_copper_chestplate": "Waxed Exposed Copper Chestplate",
+  "item.coppertools.waxed_exposed_copper_leggings":   "Waxed Exposed Copper Leggings",
+  "item.coppertools.waxed_exposed_copper_boots":      "Waxed Exposed Copper Boots",
+  
+  "item.coppertools.waxed_weathered_copper_shovel":  "Waxed Weathered Copper Shovel",
+  "item.coppertools.waxed_weathered_copper_pickaxe": "Waxed Weathered Copper Pickaxe",
+  "item.coppertools.waxed_weathered_copper_axe":     "Waxed Weathered Copper Axe",
+  "item.coppertools.waxed_weathered_copper_hoe":     "Waxed Weathered Copper Hoe",
+  "item.coppertools.waxed_weathered_copper_sword":   "Waxed Weathered Copper Sword",
+  
+  "item.coppertools.waxed_weathered_copper_helmet":     "Waxed Weathered Copper Helmet",
+  "item.coppertools.waxed_weathered_copper_chestplate": "Waxed Weathered Copper Chestplate",
+  "item.coppertools.waxed_weathered_copper_leggings":   "Waxed Weathered Copper Leggings",
+  "item.coppertools.waxed_weathered_copper_boots":      "Waxed Weathered Copper Boots",
+  
+  "item.coppertools.waxed_oxidized_copper_shovel":  "Waxed Oxidized Copper Shovel",
+  "item.coppertools.waxed_oxidized_copper_pickaxe": "Waxed Oxidized Copper Pickaxe",
+  "item.coppertools.waxed_oxidized_copper_axe":     "Waxed Oxidized Copper Axe",
+  "item.coppertools.waxed_oxidized_copper_hoe":     "Waxed Oxidized Copper Hoe",
+  "item.coppertools.waxed_oxidized_copper_sword":   "Waxed Oxidized Copper Sword",
+  
+  "item.coppertools.waxed_oxidized_copper_helmet":     "Waxed Oxidized Copper Helmet",
+  "item.coppertools.waxed_oxidized_copper_chestplate": "Waxed Oxidized Copper Chestplate",
+  "item.coppertools.waxed_oxidized_copper_leggings":   "Waxed Oxidized Copper Leggings",
+  "item.coppertools.waxed_oxidized_copper_boots":      "Waxed Oxidized Copper Boots"
 }

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_axe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_axe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/copper_axe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_boots.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_boots.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/copper_boots"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_chestplate.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_chestplate.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/copper_chestplate"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_helmet.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_helmet.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/copper_helmet"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_hoe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_hoe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/copper_hoe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_leggings.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_leggings.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/copper_leggings"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_pickaxe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/copper_pickaxe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_shovel.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_shovel.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/copper_shovel"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_copper_sword.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_copper_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/copper_sword"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_axe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_axe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_axe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_boots.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_boots.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_boots"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_chestplate.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_chestplate.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_chestplate"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_helmet.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_helmet.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_helmet"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_hoe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_hoe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_hoe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_leggings.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_leggings.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_leggings"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_pickaxe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_pickaxe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_shovel.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_shovel.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_shovel"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_sword.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_exposed_copper_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/exposed_copper_sword"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_axe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_axe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_axe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_boots.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_boots.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_boots"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_chestplate.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_chestplate.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_chestplate"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_helmet.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_helmet.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_helmet"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_hoe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_hoe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_hoe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_leggings.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_leggings.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_leggings"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_pickaxe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_pickaxe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_shovel.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_shovel.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_shovel"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_sword.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_oxidized_copper_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/oxidized_copper_sword"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_axe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_axe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_axe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_boots.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_boots.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_boots"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_chestplate.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_chestplate.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_chestplate"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_helmet.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_helmet.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_helmet"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_hoe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_hoe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_hoe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_leggings.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_leggings.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_leggings"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_pickaxe.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_pickaxe"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_shovel.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_shovel.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_shovel"
+  }
+}

--- a/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_sword.json
+++ b/src/main/resources/assets/coppertools/models/item/waxed_weathered_copper_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "coppertools:items/weathered_copper_sword"
+  }
+}


### PR DESCRIPTION
All copper blocks in vanilla Minecraft have waxed variants, so an equivalent waxed variant of every copper tool and armor piece has been added. They also share the same textures along with their non-waxed variant.