### PR TITLE
Add Oxidizations to Items

### DIFF
--- a/src/main/java/com/github/shadowgry/coppertools/CopperTools.java
+++ b/src/main/java/com/github/shadowgry/coppertools/CopperTools.java
@@ -17,10 +17,12 @@
  */
 package com.github.shadowgry.coppertools;
 
+import com.github.shadowgry.coppertools.client.events.ModEventHandler;
 import com.github.shadowgry.coppertools.common.items.ModItems;
 
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod(CopperTools.MOD_ID)
@@ -28,7 +30,8 @@ public class CopperTools {
     public static final String MOD_ID = "coppertools";
     
     public CopperTools() {
-        ModItems.registerItems();;
+        ModItems.registerItems();
+        MinecraftForge.EVENT_BUS.register(new ModEventHandler());
     }
     
     public static final CreativeModeTab TAB_COPPER_TOOLS = new CreativeModeTab("copper_tools") {

--- a/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
+++ b/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
@@ -101,8 +101,7 @@ public class ModEventHandler {
         int size = items.size() - 1;
         for(int i = 0; i < size; i++) {
             oxidizeData.put(((Item) items.get(i).get()).asItem(),
-                            new OxidizeData(((Item) items.get(i+1).get()).getDefaultInstance(),
-                                            OXIDIZE_DAMAGE[i], START_DAMAGE[i]));
+                            new OxidizeData((Item) items.get(i+1).get(), OXIDIZE_DAMAGE[i], START_DAMAGE[i]));
         }
     }
     
@@ -121,9 +120,9 @@ public class ModEventHandler {
             OxidizeData data = oxidizeData.get(item.getItem());
 
             if(data != null && item.getDamageValue() > data.getOxidizeDamageValue()) {
-                ItemStack nextPickaxe = data.getNextTool();
-                nextPickaxe.setDamageValue(data.getStartDamageValue());
-                player.setItemInHand(InteractionHand.MAIN_HAND, nextPickaxe);
+                ItemStack nextTool = data.getNextTool().getDefaultInstance();
+                nextTool.setDamageValue(data.getStartDamageValue());
+                player.setItemInHand(InteractionHand.MAIN_HAND, nextTool);
             }
         }
     }
@@ -134,7 +133,7 @@ public class ModEventHandler {
      * is recommended to use a map to store it and map it to the appropriate instance of this class.
      */
     private class OxidizeData {
-        private ItemStack nextTool;
+        private Item nextTool;
         private int oxidizeDamageValue;
         private int startDamageValue;
         
@@ -145,7 +144,7 @@ public class ModEventHandler {
          * @param oxidizeDamageValue the damage value required for the previous tool to oxidize into {@code nextTool}
          * @param startDamageValue the initial damage of {@code nextTool}
          */
-        OxidizeData(ItemStack nextTool, int oxidizeDamageValue, int startDamageValue) {
+        OxidizeData(Item nextTool, int oxidizeDamageValue, int startDamageValue) {
             this.nextTool = nextTool;
             this.oxidizeDamageValue = oxidizeDamageValue;
             this.startDamageValue = startDamageValue;
@@ -156,7 +155,7 @@ public class ModEventHandler {
          * 
          * @return the next tool the old one turns into.
          */
-        ItemStack getNextTool() {
+        Item getNextTool() {
             return this.nextTool;
         }
         

--- a/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
+++ b/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
@@ -17,42 +17,137 @@
  */
 package com.github.shadowgry.coppertools.client.events;
 
-import com.github.shadowgry.coppertools.CopperTools;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.github.shadowgry.coppertools.common.items.ModItems;
+import com.github.shadowgry.coppertools.common.items.ModTiers;
 import com.mojang.logging.LogUtils;
 
 import org.slf4j.Logger;
 
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 
-@Mod.EventBusSubscriber(modid = CopperTools.MOD_ID, bus = Bus.FORGE, value = Dist.CLIENT)
+/**
+ * Implements copper tool oxidizations.
+ */
 public class ModEventHandler {
     
     public static final Logger LOGGER = LogUtils.getLogger();
     
     /**
-     * Oxidizes a copper pickaxe into an exposed copper pickaxe after its 
-     * damage value reaches 50.
+     * Flag to denote if copper tool oxidization order has been specified.
+     */
+    private boolean isMapInitialized;
+    
+    /**
+     * Stores data to appropriately oxidize copper tools.
+     */
+    private Map<Item, OxidizeData> oxidizeData;
+    
+    public ModEventHandler() {
+        isMapInitialized  = false;
+        oxidizeData = null;
+    }
+    
+    /**
+     * Puts the copper pickaxe oxidization orderings into a map, for quick future lookup. Sets {@code isMapInitialized}
+     * to true, as this only needs to be run once.
+     * 
+     * TODO: Run earlier during mod loading, rather than on first BreakEvent. 
+     */
+    private void initializeMap() {
+        oxidizeData = new HashMap<>();
+        oxidizeData.put(ModItems.COPPER_PICKAXE.get().asItem(),
+                        new OxidizeData(ModItems.EXPOSED_COPPER_PICKAXE.get().getDefaultInstance(),
+                            ModTiers.COPPER.getUses()/4,
+                            ModTiers.EXPOSED_COPPER.getUses()/4));
+        oxidizeData.put(ModItems.EXPOSED_COPPER_PICKAXE.get().asItem(),
+                        new OxidizeData(ModItems.WEATHERED_COPPER_PICKAXE.get().getDefaultInstance(),
+                            ModTiers.EXPOSED_COPPER.getUses() * 1/2,
+                            ModTiers.WEATHERED_COPPER.getUses() * 1/2));
+        oxidizeData.put(ModItems.WEATHERED_COPPER_PICKAXE.get().asItem(),
+                        new OxidizeData(ModItems.OXIDIZED_COPPER_PICKAXE.get().getDefaultInstance(),
+                                ModTiers.WEATHERED_COPPER.getUses() * 3/4,
+                                ModTiers.OXIDIZED_COPPER.getUses() * 3/4));
+        isMapInitialized = true;
+    }
+    
+    /**
+     * Oxidizes copper pickaxes to the next stage when they are damaged enough.
      */
     @SubscribeEvent
-    public static void onBreakEvent(BreakEvent event) {
+    public void onBreakEvent(BreakEvent event) {
+        if(!isMapInitialized) {
+            initializeMap();
+        }
+        
         Player player = event.getPlayer();
         if(!player.isCreative()) {
             ItemStack item = player.getMainHandItem();
-            if(item.getItem() == ModItems.COPPER_PICKAXE.get().asItem()) {
-                if(item.getDamageValue() > 50) {
-                    ItemStack oxidizedTool = ModItems.EXPOSED_COPPER_PICKAXE.get().getDefaultInstance();
-                    oxidizedTool.setDamageValue(40);
-                    player.setItemInHand(InteractionHand.MAIN_HAND, oxidizedTool);
-                }
+            OxidizeData data = oxidizeData.get(item.getItem());
+
+            if(data != null && item.getDamageValue() > data.getOxidizeDamageValue()) {
+                ItemStack nextPickaxe = data.getNextTool();
+                nextPickaxe.setDamageValue(data.getStartDamageValue());
+                player.setItemInHand(InteractionHand.MAIN_HAND, nextPickaxe);
             }
+        }
+    }
+    
+    /**
+     * Stores information to appropriately oxidize a copper tool to the next tool. Copper tools oxidize in a linear way.
+     * The current (or previous tool) oxidizes to {@nextTool}, however, previous tool is not stored in this class - it
+     * is recommended to use a map to store it and map it to the appropriate instance of this class.
+     */
+    private class OxidizeData {
+        private ItemStack nextTool;
+        private int oxidizeDamageValue;
+        private int startDamageValue;
+        
+        /**
+         * Creates a new cache to store information about a particular copper tool oxidization.
+         * 
+         * @param nextTool the new tool the old one turns into
+         * @param oxidizeDamageValue the damage value required for the previous tool to oxidize into {@code nextTool}
+         * @param startDamageValue the initial damage of {@code nextTool}
+         */
+        OxidizeData(ItemStack nextTool, int oxidizeDamageValue, int startDamageValue) {
+            this.nextTool = nextTool;
+            this.oxidizeDamageValue = oxidizeDamageValue;
+            this.startDamageValue = startDamageValue;
+        }
+        
+        /**
+         * Returns the next tool the old one turns into.
+         * 
+         * @return the next tool the old one turns into.
+         */
+        ItemStack getNextTool() {
+            return this.nextTool;
+        }
+        
+        /**
+         * Returns the damage value required for the previous tool to oxidize into {@code nextTool}.
+         * 
+         * @return the damage value required for the previous tool to oxidize into {@code nextTool}
+         */
+        int getOxidizeDamageValue() {
+            return this.oxidizeDamageValue;
+        }
+        
+        /**
+         * Returns the initial damage of {@code nextTool}.
+         * 
+         * @return the initial damage of {@code nextTool}
+         */
+        int getStartDamageValue() {
+            return this.startDamageValue;
         }
     }
 }

--- a/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
+++ b/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
@@ -50,6 +50,24 @@ public class ModEventHandler {
      */
     private Map<Item, OxidizeData> oxidizeData;
     
+    /**
+     * The damage value required before the tool oxidizes to the next stage.
+     */
+    private final int[] OXIDIZE_DAMAGE = new int[] {
+        ModTiers.COPPER.getUses() / 4,
+        ModTiers.EXPOSED_COPPER.getUses() * 1/2,
+        ModTiers.WEATHERED_COPPER.getUses() * 3/4
+    };
+    
+    /**
+     * The initial damage of the next oxidized tool.
+     */
+    private final int[] START_DAMAGE = new int[] {
+        ModTiers.EXPOSED_COPPER.getUses() / 4,
+        ModTiers.WEATHERED_COPPER.getUses() * 1/2,
+        ModTiers.OXIDIZED_COPPER.getUses() * 3/4
+    };
+    
     public ModEventHandler() {
         isMapInitialized  = false;
         oxidizeData = null;
@@ -63,23 +81,62 @@ public class ModEventHandler {
      */
     private void initializeMap() {
         oxidizeData = new HashMap<>();
+        
+        oxidizeData.put(ModItems.COPPER_SHOVEL.get().asItem(),
+                        new OxidizeData(ModItems.EXPOSED_COPPER_SHOVEL.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
+        oxidizeData.put(ModItems.EXPOSED_COPPER_SHOVEL.get().asItem(),
+                        new OxidizeData(ModItems.WEATHERED_COPPER_SHOVEL.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
+        oxidizeData.put(ModItems.WEATHERED_COPPER_HOE.get().asItem(),
+                        new OxidizeData(ModItems.OXIDIZED_COPPER_SHOVEL.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
+        
         oxidizeData.put(ModItems.COPPER_PICKAXE.get().asItem(),
                         new OxidizeData(ModItems.EXPOSED_COPPER_PICKAXE.get().getDefaultInstance(),
-                            ModTiers.COPPER.getUses()/4,
-                            ModTiers.EXPOSED_COPPER.getUses()/4));
+                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
         oxidizeData.put(ModItems.EXPOSED_COPPER_PICKAXE.get().asItem(),
                         new OxidizeData(ModItems.WEATHERED_COPPER_PICKAXE.get().getDefaultInstance(),
-                            ModTiers.EXPOSED_COPPER.getUses() * 1/2,
-                            ModTiers.WEATHERED_COPPER.getUses() * 1/2));
+                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
         oxidizeData.put(ModItems.WEATHERED_COPPER_PICKAXE.get().asItem(),
                         new OxidizeData(ModItems.OXIDIZED_COPPER_PICKAXE.get().getDefaultInstance(),
-                                ModTiers.WEATHERED_COPPER.getUses() * 3/4,
-                                ModTiers.OXIDIZED_COPPER.getUses() * 3/4));
+                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
+        
+        oxidizeData.put(ModItems.COPPER_AXE.get().asItem(),
+                        new OxidizeData(ModItems.EXPOSED_COPPER_AXE.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
+        oxidizeData.put(ModItems.EXPOSED_COPPER_AXE.get().asItem(),
+                        new OxidizeData(ModItems.WEATHERED_COPPER_AXE.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
+        oxidizeData.put(ModItems.WEATHERED_COPPER_AXE.get().asItem(),
+                        new OxidizeData(ModItems.OXIDIZED_COPPER_AXE.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
+        
+        oxidizeData.put(ModItems.COPPER_HOE.get().asItem(),
+                        new OxidizeData(ModItems.EXPOSED_COPPER_HOE.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
+        oxidizeData.put(ModItems.EXPOSED_COPPER_HOE.get().asItem(),
+                        new OxidizeData(ModItems.WEATHERED_COPPER_HOE.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
+        oxidizeData.put(ModItems.WEATHERED_COPPER_HOE.get().asItem(),
+                        new OxidizeData(ModItems.OXIDIZED_COPPER_HOE.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
+        
+        oxidizeData.put(ModItems.COPPER_SWORD.get().asItem(),
+                        new OxidizeData(ModItems.EXPOSED_COPPER_SWORD.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
+        oxidizeData.put(ModItems.EXPOSED_COPPER_SWORD.get().asItem(),
+                        new OxidizeData(ModItems.WEATHERED_COPPER_SWORD.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
+        oxidizeData.put(ModItems.WEATHERED_COPPER_SWORD.get().asItem(),
+                        new OxidizeData(ModItems.OXIDIZED_COPPER_SWORD.get().getDefaultInstance(),
+                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
+        
         isMapInitialized = true;
     }
     
     /**
-     * Oxidizes copper pickaxes to the next stage when they are damaged enough.
+     * Oxidizes copper tools to the next stage when they are damaged enough from breaking blocks.
      */
     @SubscribeEvent
     public void onBreakEvent(BreakEvent event) {

--- a/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
+++ b/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
@@ -33,6 +33,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.registries.RegistryObject;
@@ -112,11 +113,29 @@ public class ModEventHandler {
      */
     @SubscribeEvent
     public void onBreakEvent(BreakEvent event) {
+        Player player = event.getPlayer();
+        oxidizeTool(player);
+    }
+    
+    /**
+     * Oxidizes copper tools to the next stage when they are damaged enough from modifying blocks.
+     */
+    @SubscribeEvent
+    public void onToolModificationEvent(BlockEvent.BlockToolModificationEvent event) {
+        Player player = event.getPlayer();
+        oxidizeTool(player);
+    }
+    
+    /**
+     * Oxidizes a tool in the selected player's hand if it is damaged enough.
+     * 
+     * @param player the player where an oxidization may occur.
+     */
+    private void oxidizeTool(Player player) {
         if(!isMapInitialized) {
             initializeMap();
         }
         
-        Player player = event.getPlayer();
         if(!player.isCreative()) {
             ItemStack item = player.getMainHandItem();
             OxidizeData data = oxidizeData.get(item.getItem());

--- a/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
+++ b/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
@@ -18,6 +18,7 @@
 package com.github.shadowgry.coppertools.client.events;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.github.shadowgry.coppertools.common.items.ModItems;
@@ -32,6 +33,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.registries.RegistryObject;
 
 /**
  * Implements copper tool oxidizations.
@@ -74,65 +76,34 @@ public class ModEventHandler {
     }
     
     /**
-     * Puts the copper pickaxe oxidization orderings into a map, for quick future lookup. Sets {@code isMapInitialized}
-     * to true, as this only needs to be run once.
+     * Puts the copper tool oxidization orderings into a map, for quick future lookup. Sets {@code isMapInitialized} to
+     * true, as this only needs to be run once.
      * 
      * TODO: Run earlier during mod loading, rather than on first BreakEvent. 
      */
     private void initializeMap() {
+        List< List<RegistryObject<?>> > copper_tools = List.of(
+            List.of(ModItems.COPPER_SHOVEL, ModItems.EXPOSED_COPPER_SHOVEL, ModItems.WEATHERED_COPPER_SHOVEL, ModItems.OXIDIZED_COPPER_SHOVEL),
+            List.of(ModItems.COPPER_PICKAXE, ModItems.EXPOSED_COPPER_PICKAXE, ModItems.WEATHERED_COPPER_PICKAXE, ModItems.OXIDIZED_COPPER_PICKAXE),
+            List.of(ModItems.COPPER_AXE, ModItems.EXPOSED_COPPER_AXE, ModItems.WEATHERED_COPPER_AXE, ModItems.OXIDIZED_COPPER_AXE),
+            List.of(ModItems.COPPER_HOE, ModItems.EXPOSED_COPPER_HOE, ModItems.WEATHERED_COPPER_HOE, ModItems.OXIDIZED_COPPER_HOE),
+            List.of(ModItems.COPPER_SWORD, ModItems.EXPOSED_COPPER_SWORD, ModItems.WEATHERED_COPPER_SWORD, ModItems.OXIDIZED_COPPER_SWORD)
+        );
+        
         oxidizeData = new HashMap<>();
-        
-        oxidizeData.put(ModItems.COPPER_SHOVEL.get().asItem(),
-                        new OxidizeData(ModItems.EXPOSED_COPPER_SHOVEL.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
-        oxidizeData.put(ModItems.EXPOSED_COPPER_SHOVEL.get().asItem(),
-                        new OxidizeData(ModItems.WEATHERED_COPPER_SHOVEL.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
-        oxidizeData.put(ModItems.WEATHERED_COPPER_HOE.get().asItem(),
-                        new OxidizeData(ModItems.OXIDIZED_COPPER_SHOVEL.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
-        
-        oxidizeData.put(ModItems.COPPER_PICKAXE.get().asItem(),
-                        new OxidizeData(ModItems.EXPOSED_COPPER_PICKAXE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
-        oxidizeData.put(ModItems.EXPOSED_COPPER_PICKAXE.get().asItem(),
-                        new OxidizeData(ModItems.WEATHERED_COPPER_PICKAXE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
-        oxidizeData.put(ModItems.WEATHERED_COPPER_PICKAXE.get().asItem(),
-                        new OxidizeData(ModItems.OXIDIZED_COPPER_PICKAXE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
-        
-        oxidizeData.put(ModItems.COPPER_AXE.get().asItem(),
-                        new OxidizeData(ModItems.EXPOSED_COPPER_AXE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
-        oxidizeData.put(ModItems.EXPOSED_COPPER_AXE.get().asItem(),
-                        new OxidizeData(ModItems.WEATHERED_COPPER_AXE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
-        oxidizeData.put(ModItems.WEATHERED_COPPER_AXE.get().asItem(),
-                        new OxidizeData(ModItems.OXIDIZED_COPPER_AXE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
-        
-        oxidizeData.put(ModItems.COPPER_HOE.get().asItem(),
-                        new OxidizeData(ModItems.EXPOSED_COPPER_HOE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
-        oxidizeData.put(ModItems.EXPOSED_COPPER_HOE.get().asItem(),
-                        new OxidizeData(ModItems.WEATHERED_COPPER_HOE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
-        oxidizeData.put(ModItems.WEATHERED_COPPER_HOE.get().asItem(),
-                        new OxidizeData(ModItems.OXIDIZED_COPPER_HOE.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
-        
-        oxidizeData.put(ModItems.COPPER_SWORD.get().asItem(),
-                        new OxidizeData(ModItems.EXPOSED_COPPER_SWORD.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[0], START_DAMAGE[0]));
-        oxidizeData.put(ModItems.EXPOSED_COPPER_SWORD.get().asItem(),
-                        new OxidizeData(ModItems.WEATHERED_COPPER_SWORD.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[1], START_DAMAGE[1]));
-        oxidizeData.put(ModItems.WEATHERED_COPPER_SWORD.get().asItem(),
-                        new OxidizeData(ModItems.OXIDIZED_COPPER_SWORD.get().getDefaultInstance(),
-                            OXIDIZE_DAMAGE[2], START_DAMAGE[2]));
-        
+        for(List<RegistryObject<?>> tool_set : copper_tools) {
+            addOxidizeData(tool_set);
+        }
         isMapInitialized = true;
+    }
+    
+    private void addOxidizeData(List<RegistryObject<?>> items) {
+        int size = items.size() - 1;
+        for(int i = 0; i < size; i++) {
+            oxidizeData.put(((Item) items.get(i).get()).asItem(),
+                            new OxidizeData(((Item) items.get(i+1).get()).getDefaultInstance(),
+                                            OXIDIZE_DAMAGE[i], START_DAMAGE[i]));
+        }
     }
     
     /**

--- a/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
+++ b/src/main/java/com/github/shadowgry/coppertools/client/events/ModEventHandler.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Copper Tools.
+ * Copyright (C) 2022  ShadowGry
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.github.shadowgry.coppertools.client.events;
+
+import com.github.shadowgry.coppertools.CopperTools;
+import com.github.shadowgry.coppertools.common.items.ModItems;
+import com.mojang.logging.LogUtils;
+
+import org.slf4j.Logger;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.world.BlockEvent.BreakEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+
+@Mod.EventBusSubscriber(modid = CopperTools.MOD_ID, bus = Bus.FORGE, value = Dist.CLIENT)
+public class ModEventHandler {
+    
+    public static final Logger LOGGER = LogUtils.getLogger();
+    
+    /**
+     * Oxidizes a copper pickaxe into an exposed copper pickaxe after its 
+     * damage value reaches 50.
+     */
+    @SubscribeEvent
+    public static void onBreakEvent(BreakEvent event) {
+        Player player = event.getPlayer();
+        if(!player.isCreative()) {
+            ItemStack item = player.getMainHandItem();
+            if(item.getItem() == ModItems.COPPER_PICKAXE.get().asItem()) {
+                if(item.getDamageValue() > 50) {
+                    ItemStack oxidizedTool = ModItems.EXPOSED_COPPER_PICKAXE.get().getDefaultInstance();
+                    oxidizedTool.setDamageValue(40);
+                    player.setItemInHand(InteractionHand.MAIN_HAND, oxidizedTool);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This branch has been going on for too long, and the scope may have been too big for it. With the need to port to 1.19 sooner rather than later, it is time to merge what has been implemented so far.

This pull request adds:
- Oxidization of all tools after `BlockEvent.BreakEvent` and `BlockEvent.BlockToolModificationEvent` events (depending on tool damage values).
- Custom item names and enchantments are preserved after an oxidization.

The remaining need to add oxidization of swords after attacking, and of armor after taking damage, will be added in future pull requests.